### PR TITLE
fix: updated bucket secrets URL to use versioned endpoint `/v1/bucket…

### DIFF
--- a/frontend/src/lib/api/bucket-secrets/index.ts
+++ b/frontend/src/lib/api/bucket-secrets/index.ts
@@ -53,7 +53,7 @@ export class BucketSecretsApi {
 
   async getBucketSecretConnectionUrls(data: BucketFormData) {
     const { data: responseData } = await this.api.post<BucketConnectionUrls>(
-      `bucket-secrets/urls`,
+      `/v1/bucket-secrets/urls`,
       data,
     )
     return responseData


### PR DESCRIPTION
…-secrets/urls`